### PR TITLE
[FIX]修复go.mod项目不对的问题，导致contrib采用go mod模式tidy不过得问题

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/holmeswang/redistore
+module github.com/Demoliang/redistore
 
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/boj/redistore
+module github.com/holmeswang/redistore
 
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible


### PR DESCRIPTION
我发现引用你的项目的时候，这整个的go.mod的文件不对
module github.com/boj/redistore
你写的是这个，还是原有的mod的文件，但是实际上得更新这个文件为
module github.com/holmeswang/redistore
