### PR TITLE
fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/boj/redistore
+module holmeswang/redistore
 
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module holmeswang/redistore
+module github.com/holmeswang/redistore
 
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible


### PR DESCRIPTION
The module name should be holmeswang/redistore, not boj/redistore.
It will trigger bk-cmdb go mod failure.